### PR TITLE
Chatbox Alignment, Meteor angle change and overflow fixes

### DIFF
--- a/public/css/background.css
+++ b/public/css/background.css
@@ -563,6 +563,24 @@
     transform: translateY(-2000px);
   }
 }
+.bottom-center{
+  transform: scale(0.6);
+  position: absolute;
+  bottom: -50vh;
+  left: 10vw;
+}
+.bottom-right{
+  transform: scale(0.6);
+  position: absolute;
+  bottom: -55vh;
+  right: -10vw;
+}
+.top-right{
+  transform: scale(0.6);
+  position: absolute;
+  top: -8vh;
+  right: -10vw;
+}
 @media (max-width: 1024px) {
   .hero {
     background-size: 1500px;

--- a/public/css/background.css
+++ b/public/css/background.css
@@ -572,13 +572,13 @@
 .bottom-right{
   transform: scale(0.6);
   position: absolute;
-  bottom: -55vh;
-  right: -10vw;
+  bottom: -60vh;
+  right: -13vw;
 }
 .top-right{
   transform: scale(0.6);
   position: absolute;
-  top: -8vh;
+  top: -15vh;
   right: -10vw;
 }
 @media (max-width: 1024px) {

--- a/public/css/herostyles.css
+++ b/public/css/herostyles.css
@@ -375,6 +375,80 @@
   justify-content: space-around;
   align-items: center;
 }
+@media(max-width:1024px) and (min-width:849px) {
+  .hero{
+    height: 900px !important;
+  }
+  .hero__content__details{
+    transform: scale(1.3)
+  }
+  .bottom-right{
+    position: absolute;
+    bottom: 0;
+    left: -40vw;
+  }
+  .top-right{
+    right: -20vw !important;
+  }
+}
+@media(max-width:850px) and (min-width:600px){
+  .hero{
+    height: 950px !important;
+  }
+  .hero__content__details{
+    transform: scale(1.3)
+  }
+  .top-right{
+    right: 50vw !important;
+    top: 110vh !important;
+  }
+  .bottom-right{
+    bottom: -80vh !important;
+    right: 0 !important;
+  }
+  .bottom-center{
+    bottom: -65vh !important;
+  }
+}
+@media(max-width:600px) and (min-width:425px){
+  .hero{
+    height: 850px !important;
+  }
+  .hero__content__details{
+    transform: scale(1);
+  }
+  .top-right{
+    right: 20vw !important;
+    top: 90vh !important;
+  }
+  .bottom-right{
+    bottom: -80vh !important;
+    right: -43vw !important;
+  }
+  .bottom-center{
+    bottom: -65vh !important;
+  }
+}
+@media(max-width:425px){
+  .hero{
+    height: 850px !important;
+  }
+  .chat{
+    width: 320px !important;
+    height: 225px !important;
+  }
+  .top-right{
+    right: 5vw !important;
+    top: 90vh !important;
+  }
+  .bottom-right{
+    bottom: -90vh !important;
+    right: -60vw !important;
+  }
+  .bottom-center{
+    bottom: -65vh !important;
+  }
+}
 @media (max-width: 1024px) {
   .hero {
     background-size: 1500px;

--- a/public/css/herostyles.css
+++ b/public/css/herostyles.css
@@ -153,7 +153,7 @@
   padding: 0 15px;
   overflow: hidden;
   position: relative;
-  z-index: 100;
+  z-index: 2;
   margin-top: 50px;
   display: flex;
   /* display: none; */

--- a/public/css/herostyles.css
+++ b/public/css/herostyles.css
@@ -139,22 +139,24 @@
   transform: scale(1.05);
 }
 .hero__content .chat {
-  backdrop-filter: blur(4px);
+  /* backdrop-filter: blur(4px); */
   font-family: lato, sans-serif;
   border-radius: 15px;
   color: black;
-  background: transparent;
-  border-bottom: 1px solid #ff416c;
-  box-shadow: 0 3px 3px -2px #ff416c;
+  background: #00172C;
+  border-bottom: 1px solid #c1002c;
+  box-shadow: 0 5px 3px -2px #c1002c;
   width: 400px;
   height: 250px;
-  display: flex;
   flex-direction: column;
   justify-content: flex-end;
   padding: 0 15px;
   overflow: hidden;
   position: relative;
-  margin-bottom: 30px;
+  z-index: 100;
+  margin-top: 50px;
+  display: flex;
+  /* display: none; */
 }
 .hero__content .chat__header {
   position: absolute;

--- a/public/css/herostyles.css
+++ b/public/css/herostyles.css
@@ -376,6 +376,24 @@
   justify-content: space-around;
   align-items: center;
 }
+@media(min-width:1440px){
+  .hero__content__details{
+    transform: scale(1.2);
+  }
+  .chat{
+    transform: scale(1.3);
+    position: relative;
+    top: 10vh !important;
+    right: -5vw !important;
+  }
+}
+@media(max-width: 1440px) and (min-width: 1024px){
+  .chat{
+    position: relative;
+    top: 7vh !important;
+    right: -5vw !important;
+  }
+}
 @media(max-width:1024px) and (min-width:849px) {
   .hero{
     height: 900px !important;

--- a/public/css/meteor.css
+++ b/public/css/meteor.css
@@ -85,7 +85,7 @@
   left: 15%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 4.7s linear infinite;
 }
@@ -105,7 +105,7 @@
   left: 30%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 6.3s linear infinite;
 }
@@ -125,7 +125,7 @@
   left: 91%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 7.5s linear infinite;
 }
@@ -145,7 +145,7 @@
   left: 74%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 8.6s linear infinite;
 }
@@ -165,7 +165,7 @@
   left: 99%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 5.3s linear infinite;
 }
@@ -185,7 +185,7 @@
   left: 34%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 6.1s linear infinite;
 }
@@ -205,7 +205,7 @@
   left: 45%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 9.1s linear infinite;
 }
@@ -225,7 +225,7 @@
   left: 68%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 9.2s linear infinite;
 }
@@ -245,7 +245,7 @@
   left: 72%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 3.7s linear infinite;
 }
@@ -265,7 +265,7 @@
   left: 73%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 4.4s linear infinite;
 }
@@ -285,7 +285,7 @@
   left: 66%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 9.4s linear infinite;
 }
@@ -305,7 +305,7 @@
   left: 64%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 8s linear infinite;
 }
@@ -325,7 +325,7 @@
   left: 71%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 4.4s linear infinite;
 }
@@ -345,7 +345,7 @@
   left: 74%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 8.7s linear infinite;
 }
@@ -365,7 +365,7 @@
   left: 83%;
   width: 300px;
   height: 1px;
-  transform: rotate(-45deg);
+  transform: rotate(-32deg);
   background-image: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
   animation: meteor 3.2s linear infinite;
 }

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -156,6 +156,58 @@
               </div>
             </div>
             <div class="hero__content__banner">
+              <div class="chat">
+                <div class="header chat__header">
+                  <div class="header__title">Dotslash Server</div>
+                  <div class="header__members">
+                    <div class="header__member"></div>
+                    <div class="header_member header_member--server"></div>
+                  </div>
+                </div>
+                <div class="message message--browser">
+                  <div class="message__content">Hey Server</div>
+                </div>
+                <div class="message message--server">
+                  <div class="message__content">Hey Folk 👋</div>
+                </div>
+                <div class="message message--browser">
+                  <div class="message__content">What is the date of hackathon?</div>
+                </div>
+                <div class="message message--server">
+                  <div class="message__content">It's 30-31st Jan 2021</div>
+                </div>
+                <div class="message message--browser">
+                  <div class="message__content">OK</div>
+                </div>
+                <div class="message message--browser">
+                  <div class="message__content">What's the last date of registration?</div>
+                </div>
+                <div class="message message--server">
+                  <div class="message__content">9th Jan 2021</div>
+                </div>
+                <div class="message message--browser">
+                  <div class="message__content">What is the mode of conduct?</div>
+                </div>
+                <div class="message message--server">
+                  <div class="message__content">Online</div>
+                </div>
+                <div class="message message--server">
+                  <div class="message__content">Anything else??</div>
+                </div>
+                <div class="message message--server">
+                  <div class="message__content">You still there??</div>
+                </div>
+                <div class="message message--left">
+                  <div class="message__content">Server left the chat</div>
+                </div>
+                <div class="message message--typing message--browser">
+                  <div class="message__content">
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                  </div>
+                </div>
+              </div>
               <svg
                 class="bottom-center"
                 width="983"

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -394,92 +394,119 @@
                 </defs>
               </svg>
 
-              <svg class="bottom-right"width="866" height="507" viewBox="0 0 866 507" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M865.5 51V28L840.5 21L166 432H234L865.5 51Z" fill="url(#paint0_linear)"/>
-<path d="M701.5 64.5L703.5 40L678.5 33.5L4 444.5H72L701.5 64.5Z" stroke="url(#paint1_linear)" stroke-width="2"/>
-<path d="M750.5 145L327 414.5H400L775.5 177V153.5L750.5 145Z" stroke="url(#paint2_linear)" stroke-width="2"/>
-<path d="M515 332L327 445H393.5L537 363V340.5L515 332Z" fill="url(#paint3_linear)"/>
-<path d="M838.5 129L695 216.5L691 245L717.5 252L860 163.5V136.5L838.5 129Z" fill="url(#paint4_linear)"/>
-<path d="M695 259L551 348V372.5L574 382L716.5 293.5V266.5L695 259Z" stroke="url(#paint5_linear)" stroke-width="2"/>
-<path d="M540 382L396 471V495.5L419 505L561.5 416.5V389.5L540 382Z" stroke="url(#paint6_linear)" stroke-width="2"/>
-<path d="M764.5 0.5L621 88V113L643.5 123.5L786 35V8L764.5 0.5Z" fill="url(#paint7_linear)"/>
+              <svg class="bottom-right"width="900" height="595" viewBox="0 0 900 595" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M824.5 50.5V27.5L799.5 20.5L125 431.5H193L824.5 50.5Z" fill="url(#paint0_linear)"/>
+<path d="M660.5 64L662.5 39.5L637.5 33L-37 444H31L660.5 64Z" stroke="url(#paint1_linear)" stroke-width="2"/>
+<path d="M709.5 144.5L286 414H359L734.5 176.5V153L709.5 144.5Z" stroke="url(#paint2_linear)" stroke-width="2"/>
+<path d="M474 331.5L342 415.5V440.5L362 448.5L496 362.5V340L474 331.5Z" fill="url(#paint3_linear)"/>
+<path d="M797.5 128.5L654 216L650 244.5L676.5 251.5L819 163V136L797.5 128.5Z" fill="url(#paint4_linear)"/>
+<path d="M654 258.5L510 347.5V372L533 381.5L675.5 293V266L654 258.5Z" stroke="url(#paint5_linear)" stroke-width="2"/>
+<path d="M794 239L650 328V352.5L673 362L815.5 273.5V246.5L794 239Z" fill="url(#paint6_linear)" stroke="url(#paint7_linear)" stroke-width="2"/>
+<path d="M499 381.5L355 470.5V495L378 504.5L520.5 416V389L499 381.5Z" stroke="url(#paint8_linear)" stroke-width="2"/>
+<path d="M723.5 0L580 87.5V112.5L602.5 123L745 34.5V7.5L723.5 0Z" fill="url(#paint9_linear)"/>
+<path d="M897.5 300L899.5 275.5L874.5 269L200 680H268L897.5 300Z" fill="url(#paint10_linear)" fill-opacity="0.38"/>
 <defs>
-<linearGradient id="paint0_linear" x1="523.75" y1="21" x2="523.75" y2="432" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint0_linear" x1="482.75" y1="20.5" x2="482.75" y2="431.5" gradientUnits="userSpaceOnUse">
 <stop stop-color="#69C2BA"/>
 <stop offset="0.630208" stop-color="#30BEB0" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint1_linear" x1="353.75" y1="33.5" x2="353.75" y2="444.5" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint1_linear" x1="312.75" y1="33" x2="312.75" y2="444" gradientUnits="userSpaceOnUse">
 <stop stop-color="#4D9A93"/>
 <stop offset="0.46875" stop-color="#69C2BA" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint2_linear" x1="551.25" y1="145" x2="551.25" y2="414.5" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint2_linear" x1="510.25" y1="144.5" x2="510.25" y2="414" gradientUnits="userSpaceOnUse">
 <stop stop-color="#4D9A93"/>
 <stop offset="1" stop-color="#69C2BA" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint3_linear" x1="452.5" y1="332" x2="452.5" y2="445" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint3_linear" x1="411.5" y1="331.5" x2="411.5" y2="444.5" gradientUnits="userSpaceOnUse">
 <stop stop-color="#69C2BA"/>
 <stop offset="1" stop-color="#3F9A92" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint4_linear" x1="777.5" y1="129" x2="777.5" y2="252" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint4_linear" x1="736.5" y1="128.5" x2="736.5" y2="251.5" gradientUnits="userSpaceOnUse">
 <stop stop-color="#236361"/>
 <stop offset="0.807292" stop-color="#236361" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint5_linear" x1="634" y1="259" x2="634" y2="382" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint5_linear" x1="593" y1="258.5" x2="593" y2="381.5" gradientUnits="userSpaceOnUse">
 <stop stop-color="#236361"/>
 <stop offset="1" stop-color="#236361"/>
 </linearGradient>
-<linearGradient id="paint6_linear" x1="479" y1="382" x2="479" y2="505" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint6_linear" x1="732.75" y1="239" x2="732.75" y2="362" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="0.770833" stop-color="#236361" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint7_linear" x1="733" y1="239" x2="733" y2="362" gradientUnits="userSpaceOnUse">
 <stop stop-color="#236361"/>
 <stop offset="1" stop-color="#236361"/>
 </linearGradient>
-<linearGradient id="paint7_linear" x1="703.5" y1="0.5" x2="703.5" y2="123.5" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint8_linear" x1="438" y1="381.5" x2="438" y2="504.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="1" stop-color="#236361"/>
+</linearGradient>
+<linearGradient id="paint9_linear" x1="662.5" y1="0" x2="662.5" y2="123" gradientUnits="userSpaceOnUse">
 <stop stop-color="#236361"/>
 <stop offset="0.807292" stop-color="#236361" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint10_linear" x1="549.75" y1="269" x2="549.75" y2="680" gradientUnits="userSpaceOnUse">
+<stop stop-color="#69C2BA" stop-opacity="0.9"/>
+<stop offset="0.375" stop-color="#69C2BA" stop-opacity="0.07"/>
 </linearGradient>
 </defs>
 </svg>
-
-              <svg class="top-right" width="866" height="507" viewBox="0 0 866 507" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M865.5 51V28L840.5 21L166 432H234L865.5 51Z" fill="url(#paint0_linear)"/>
-<path d="M701.5 64.5L703.5 40L678.5 33.5L4 444.5H72L701.5 64.5Z" stroke="url(#paint1_linear)" stroke-width="2"/>
-<path d="M750.5 145L327 414.5H400L775.5 177V153.5L750.5 145Z" stroke="url(#paint2_linear)" stroke-width="2"/>
-<path d="M515 332L383 416V441L403 449L537 363V340.5L515 332Z" fill="url(#paint3_linear)"/>
-<path d="M838.5 129L695 216.5L691 245L717.5 252L860 163.5V136.5L838.5 129Z" fill="url(#paint4_linear)"/>
-<path d="M695 259L551 348V372.5L574 382L716.5 293.5V266.5L695 259Z" stroke="url(#paint5_linear)" stroke-width="2"/>
-<path d="M540 382L396 471V495.5L419 505L561.5 416.5V389.5L540 382Z" stroke="url(#paint6_linear)" stroke-width="2"/>
-<path d="M764.5 0.5L621 88V113L643.5 123.5L786 35V8L764.5 0.5Z" fill="url(#paint7_linear)"/>
+<svg class="top-right"width="900" height="595" viewBox="0 0 900 595" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M824.5 50.5V27.5L799.5 20.5L125 431.5H193L824.5 50.5Z" fill="url(#paint0_linear)"/>
+<path d="M660.5 64L662.5 39.5L637.5 33L-37 444H31L660.5 64Z" stroke="url(#paint1_linear)" stroke-width="2"/>
+<path d="M709.5 144.5L286 414H359L734.5 176.5V153L709.5 144.5Z" stroke="url(#paint2_linear)" stroke-width="2"/>
+<path d="M474 331.5L342 415.5V440.5L362 448.5L496 362.5V340L474 331.5Z" fill="url(#paint3_linear)"/>
+<path d="M797.5 128.5L654 216L650 244.5L676.5 251.5L819 163V136L797.5 128.5Z" fill="url(#paint4_linear)"/>
+<path d="M654 258.5L510 347.5V372L533 381.5L675.5 293V266L654 258.5Z" stroke="url(#paint5_linear)" stroke-width="2"/>
+<path d="M794 239L650 328V352.5L673 362L815.5 273.5V246.5L794 239Z" fill="url(#paint6_linear)" stroke="url(#paint7_linear)" stroke-width="2"/>
+<path d="M499 381.5L355 470.5V495L378 504.5L520.5 416V389L499 381.5Z" stroke="url(#paint8_linear)" stroke-width="2"/>
+<path d="M723.5 0L580 87.5V112.5L602.5 123L745 34.5V7.5L723.5 0Z" fill="url(#paint9_linear)"/>
+<path d="M897.5 300L899.5 275.5L874.5 269L200 680H268L897.5 300Z" fill="url(#paint10_linear)" fill-opacity="0.38"/>
 <defs>
-<linearGradient id="paint0_linear" x1="523.75" y1="21" x2="523.75" y2="432" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint0_linear" x1="482.75" y1="20.5" x2="482.75" y2="431.5" gradientUnits="userSpaceOnUse">
 <stop stop-color="#69C2BA"/>
 <stop offset="0.630208" stop-color="#30BEB0" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint1_linear" x1="353.75" y1="33.5" x2="353.75" y2="444.5" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint1_linear" x1="312.75" y1="33" x2="312.75" y2="444" gradientUnits="userSpaceOnUse">
 <stop stop-color="#4D9A93"/>
 <stop offset="0.46875" stop-color="#69C2BA" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint2_linear" x1="551.25" y1="145" x2="551.25" y2="414.5" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint2_linear" x1="510.25" y1="144.5" x2="510.25" y2="414" gradientUnits="userSpaceOnUse">
 <stop stop-color="#4D9A93"/>
 <stop offset="1" stop-color="#69C2BA" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint3_linear" x1="452.5" y1="332" x2="452.5" y2="445" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint3_linear" x1="411.5" y1="331.5" x2="411.5" y2="444.5" gradientUnits="userSpaceOnUse">
 <stop stop-color="#69C2BA"/>
 <stop offset="1" stop-color="#3F9A92" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint4_linear" x1="777.5" y1="129" x2="777.5" y2="252" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint4_linear" x1="736.5" y1="128.5" x2="736.5" y2="251.5" gradientUnits="userSpaceOnUse">
 <stop stop-color="#236361"/>
 <stop offset="0.807292" stop-color="#236361" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint5_linear" x1="634" y1="259" x2="634" y2="382" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint5_linear" x1="593" y1="258.5" x2="593" y2="381.5" gradientUnits="userSpaceOnUse">
 <stop stop-color="#236361"/>
 <stop offset="1" stop-color="#236361"/>
 </linearGradient>
-<linearGradient id="paint6_linear" x1="479" y1="382" x2="479" y2="505" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint6_linear" x1="732.75" y1="239" x2="732.75" y2="362" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="0.770833" stop-color="#236361" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint7_linear" x1="733" y1="239" x2="733" y2="362" gradientUnits="userSpaceOnUse">
 <stop stop-color="#236361"/>
 <stop offset="1" stop-color="#236361"/>
 </linearGradient>
-<linearGradient id="paint7_linear" x1="703.5" y1="0.5" x2="703.5" y2="123.5" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint8_linear" x1="438" y1="381.5" x2="438" y2="504.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="1" stop-color="#236361"/>
+</linearGradient>
+<linearGradient id="paint9_linear" x1="662.5" y1="0" x2="662.5" y2="123" gradientUnits="userSpaceOnUse">
 <stop stop-color="#236361"/>
 <stop offset="0.807292" stop-color="#236361" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint10_linear" x1="549.75" y1="269" x2="549.75" y2="680" gradientUnits="userSpaceOnUse">
+<stop stop-color="#69C2BA" stop-opacity="0.9"/>
+<stop offset="0.375" stop-color="#69C2BA" stop-opacity="0.07"/>
 </linearGradient>
 </defs>
 </svg>

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -156,6 +156,281 @@
               </div>
             </div>
             <div class="hero__content__banner">
+              <svg
+                class="bottom-center"
+                width="983"
+                height="473"
+                viewBox="0 0 983 473"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M953.5 30.5V7.5L928.5 0.5L254 411.5H322L953.5 30.5Z"
+                  fill="url(#paint0_linear)"
+                ></path>
+                <path
+                  d="M701.5 93L703.5 68.5L678.5 62L4 473H72L701.5 93Z"
+                  stroke="url(#paint1_linear)"
+                  stroke-width="2"
+                ></path>
+                <path
+                  d="M958 268L716 416H792L983 300V276.5L958 268Z"
+                  fill="url(#paint2_linear)"
+                ></path>
+                <path
+                  d="M929 416L687 564H763L954 448V424.5L929 416Z"
+                  fill="url(#paint3_linear)"
+                ></path>
+                <path
+                  d="M760.5 203L337 472.5H410L785.5 235V211.5L760.5 203Z"
+                  stroke="url(#paint4_linear)"
+                  stroke-width="2"
+                ></path>
+                <path
+                  d="M799 300.5L611 413.5H677.5L821 331.5V309L799 300.5Z"
+                  fill="url(#paint5_linear)"
+                ></path>
+                <path
+                  d="M889.5 152L746 239.5L768.5 275L911 186.5V159.5L889.5 152Z"
+                  fill="url(#paint6_linear)"
+                ></path>
+                <path
+                  d="M715.5 320L572 407.5L594.5 443L737 354.5V327.5L715.5 320Z"
+                  stroke="url(#paint7_linear)"
+                  stroke-width="2"
+                ></path>
+                <path
+                  d="M764.5 29L621 116.5L643.5 152L786 63.5V36.5L764.5 29Z"
+                  fill="url(#paint8_linear)"
+                ></path>
+                <defs>
+                  <linearGradient
+                    id="paint0_linear"
+                    x1="611.75"
+                    y1="0.5"
+                    x2="611.75"
+                    y2="411.5"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stop-color="#69C2BA"></stop>
+                    <stop
+                      offset="1"
+                      stop-color="#30BEB0"
+                      stop-opacity="0"
+                    ></stop>
+                  </linearGradient>
+                  <linearGradient
+                    id="paint1_linear"
+                    x1="353.75"
+                    y1="62"
+                    x2="353.75"
+                    y2="473"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stop-color="#4D9A93"></stop>
+                    <stop
+                      offset="0.46875"
+                      stop-color="#69C2BA"
+                      stop-opacity="0"
+                    ></stop>
+                  </linearGradient>
+                  <linearGradient
+                    id="paint2_linear"
+                    x1="849.5"
+                    y1="268"
+                    x2="849.5"
+                    y2="416"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stop-color="#69C2BA"></stop>
+                    <stop
+                      offset="1"
+                      stop-color="#3F9A92"
+                      stop-opacity="0"
+                    ></stop>
+                  </linearGradient>
+                  <linearGradient
+                    id="paint3_linear"
+                    x1="820.5"
+                    y1="416"
+                    x2="820.5"
+                    y2="564"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stop-color="#3F9A92"></stop>
+                    <stop
+                      offset="1"
+                      stop-color="#3F9A92"
+                      stop-opacity="0"
+                    ></stop>
+                  </linearGradient>
+                  <linearGradient
+                    id="paint4_linear"
+                    x1="561.25"
+                    y1="203"
+                    x2="561.25"
+                    y2="472.5"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stop-color="#4D9A93"></stop>
+                    <stop
+                      offset="1"
+                      stop-color="#69C2BA"
+                      stop-opacity="0"
+                    ></stop>
+                  </linearGradient>
+                  <linearGradient
+                    id="paint5_linear"
+                    x1="736.5"
+                    y1="300.5"
+                    x2="736.5"
+                    y2="413.5"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stop-color="#69C2BA"></stop>
+                    <stop
+                      offset="1"
+                      stop-color="#3F9A92"
+                      stop-opacity="0"
+                    ></stop>
+                  </linearGradient>
+                  <linearGradient
+                    id="paint6_linear"
+                    x1="828.5"
+                    y1="152"
+                    x2="828.5"
+                    y2="275"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stop-color="#236361"></stop>
+                    <stop
+                      offset="0.807292"
+                      stop-color="#236361"
+                      stop-opacity="0"
+                    ></stop>
+                  </linearGradient>
+                  <linearGradient
+                    id="paint7_linear"
+                    x1="654.5"
+                    y1="320"
+                    x2="654.5"
+                    y2="443"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stop-color="#236361"></stop>
+                    <stop
+                      offset="1"
+                      stop-color="#69C2BA"
+                      stop-opacity="0"
+                    ></stop>
+                  </linearGradient>
+                  <linearGradient
+                    id="paint8_linear"
+                    x1="703.5"
+                    y1="29"
+                    x2="703.5"
+                    y2="152"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stop-color="#236361"></stop>
+                    <stop
+                      offset="0.807292"
+                      stop-color="#236361"
+                      stop-opacity="0"
+                    ></stop>
+                  </linearGradient>
+                </defs>
+              </svg>
+
+              <svg class="bottom-right"width="866" height="507" viewBox="0 0 866 507" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M865.5 51V28L840.5 21L166 432H234L865.5 51Z" fill="url(#paint0_linear)"/>
+<path d="M701.5 64.5L703.5 40L678.5 33.5L4 444.5H72L701.5 64.5Z" stroke="url(#paint1_linear)" stroke-width="2"/>
+<path d="M750.5 145L327 414.5H400L775.5 177V153.5L750.5 145Z" stroke="url(#paint2_linear)" stroke-width="2"/>
+<path d="M515 332L327 445H393.5L537 363V340.5L515 332Z" fill="url(#paint3_linear)"/>
+<path d="M838.5 129L695 216.5L691 245L717.5 252L860 163.5V136.5L838.5 129Z" fill="url(#paint4_linear)"/>
+<path d="M695 259L551 348V372.5L574 382L716.5 293.5V266.5L695 259Z" stroke="url(#paint5_linear)" stroke-width="2"/>
+<path d="M540 382L396 471V495.5L419 505L561.5 416.5V389.5L540 382Z" stroke="url(#paint6_linear)" stroke-width="2"/>
+<path d="M764.5 0.5L621 88V113L643.5 123.5L786 35V8L764.5 0.5Z" fill="url(#paint7_linear)"/>
+<defs>
+<linearGradient id="paint0_linear" x1="523.75" y1="21" x2="523.75" y2="432" gradientUnits="userSpaceOnUse">
+<stop stop-color="#69C2BA"/>
+<stop offset="0.630208" stop-color="#30BEB0" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="353.75" y1="33.5" x2="353.75" y2="444.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4D9A93"/>
+<stop offset="0.46875" stop-color="#69C2BA" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear" x1="551.25" y1="145" x2="551.25" y2="414.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4D9A93"/>
+<stop offset="1" stop-color="#69C2BA" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint3_linear" x1="452.5" y1="332" x2="452.5" y2="445" gradientUnits="userSpaceOnUse">
+<stop stop-color="#69C2BA"/>
+<stop offset="1" stop-color="#3F9A92" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint4_linear" x1="777.5" y1="129" x2="777.5" y2="252" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="0.807292" stop-color="#236361" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint5_linear" x1="634" y1="259" x2="634" y2="382" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="1" stop-color="#236361"/>
+</linearGradient>
+<linearGradient id="paint6_linear" x1="479" y1="382" x2="479" y2="505" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="1" stop-color="#236361"/>
+</linearGradient>
+<linearGradient id="paint7_linear" x1="703.5" y1="0.5" x2="703.5" y2="123.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="0.807292" stop-color="#236361" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>
+
+              <svg class="top-right" width="866" height="507" viewBox="0 0 866 507" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M865.5 51V28L840.5 21L166 432H234L865.5 51Z" fill="url(#paint0_linear)"/>
+<path d="M701.5 64.5L703.5 40L678.5 33.5L4 444.5H72L701.5 64.5Z" stroke="url(#paint1_linear)" stroke-width="2"/>
+<path d="M750.5 145L327 414.5H400L775.5 177V153.5L750.5 145Z" stroke="url(#paint2_linear)" stroke-width="2"/>
+<path d="M515 332L383 416V441L403 449L537 363V340.5L515 332Z" fill="url(#paint3_linear)"/>
+<path d="M838.5 129L695 216.5L691 245L717.5 252L860 163.5V136.5L838.5 129Z" fill="url(#paint4_linear)"/>
+<path d="M695 259L551 348V372.5L574 382L716.5 293.5V266.5L695 259Z" stroke="url(#paint5_linear)" stroke-width="2"/>
+<path d="M540 382L396 471V495.5L419 505L561.5 416.5V389.5L540 382Z" stroke="url(#paint6_linear)" stroke-width="2"/>
+<path d="M764.5 0.5L621 88V113L643.5 123.5L786 35V8L764.5 0.5Z" fill="url(#paint7_linear)"/>
+<defs>
+<linearGradient id="paint0_linear" x1="523.75" y1="21" x2="523.75" y2="432" gradientUnits="userSpaceOnUse">
+<stop stop-color="#69C2BA"/>
+<stop offset="0.630208" stop-color="#30BEB0" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="353.75" y1="33.5" x2="353.75" y2="444.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4D9A93"/>
+<stop offset="0.46875" stop-color="#69C2BA" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear" x1="551.25" y1="145" x2="551.25" y2="414.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4D9A93"/>
+<stop offset="1" stop-color="#69C2BA" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint3_linear" x1="452.5" y1="332" x2="452.5" y2="445" gradientUnits="userSpaceOnUse">
+<stop stop-color="#69C2BA"/>
+<stop offset="1" stop-color="#3F9A92" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint4_linear" x1="777.5" y1="129" x2="777.5" y2="252" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="0.807292" stop-color="#236361" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint5_linear" x1="634" y1="259" x2="634" y2="382" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="1" stop-color="#236361"/>
+</linearGradient>
+<linearGradient id="paint6_linear" x1="479" y1="382" x2="479" y2="505" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="1" stop-color="#236361"/>
+</linearGradient>
+<linearGradient id="paint7_linear" x1="703.5" y1="0.5" x2="703.5" y2="123.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#236361"/>
+<stop offset="0.807292" stop-color="#236361" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>
 
             </div>
 


### PR DESCRIPTION
Changes made in this commit string
1. Centered discord chat box to fill in empty space between SVGs.
2. Upscaled hero elements (title and chatbox) for viewport widths greater than 1440px.
3. Changed meteor angles to match the SVG graphic.
4. Fixed overflow of chatbox onto navbar at 1024px viewport. 